### PR TITLE
Prevent error message pile-up

### DIFF
--- a/src/main/java/abex/os/keepassxc/KeePassXcPanel.java
+++ b/src/main/java/abex/os/keepassxc/KeePassXcPanel.java
@@ -123,6 +123,7 @@ public class KeePassXcPanel extends PluginPanel
 
 	public void open(String error)
 	{
+		SwingUtil.fastRemoveAll(this);
 		setLayout(new BorderLayout());
 
 		JLabel titleLabel = new JLabel("KeePassXC");


### PR DESCRIPTION
In `KeePassXcPanel#open(GetLogins.Response)`, the panel is cleared before adding the login buttons, but this clearing is not performed on `KeePassXcPanel#open(GetLogins.Response)`, which could cause error messages to pile up on top of each other, instead of replacing each other.

Without the fix, if multiple errors are encountered:
![image](https://user-images.githubusercontent.com/1868974/118315894-1c84ff80-b4c4-11eb-9b7a-cf08b8166dce.png)
