### PR TITLE
Added an option to default to the first login

### DIFF
--- a/src/main/java/abex/os/keepassxc/KeePassXcConfig.java
+++ b/src/main/java/abex/os/keepassxc/KeePassXcConfig.java
@@ -1,0 +1,20 @@
+package abex.os.keepassxc;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("keepassxc")
+public interface KeePassXcConfig extends Config
+{
+	@ConfigItem(
+			keyName = "defaultFirstEntry",
+			name = "Default to First Entry",
+			description = "Use the first login entry found in the database",
+			position = 1
+	)
+	default boolean defaultFirstEntry()
+	{
+		return false;
+	}
+}

--- a/src/main/java/abex/os/keepassxc/KeePassXcConfig.java
+++ b/src/main/java/abex/os/keepassxc/KeePassXcConfig.java
@@ -8,10 +8,20 @@ import net.runelite.client.config.ConfigItem;
 public interface KeePassXcConfig extends Config
 {
 	@ConfigItem(
-			keyName = "defaultTitle",
-			name = "Default to Entry Title",
-			description = "The Title of the login Entry to auto-populate",
+			keyName = "autoPopulate",
+			name = "Auto Populate Login",
+			description = "When enabled the KeePassXC Entry matching Title will be auto populated",
 			position = 1
+	)
+	default boolean autoPopulate()
+	{
+		return false;
+	}
+	@ConfigItem(
+			keyName = "defaultTitle",
+			name = "Title to Auto Populate",
+			description = "The Title of the login Entry to auto populate",
+			position = 2
 	)
 	default String defaultTitle()
 	{

--- a/src/main/java/abex/os/keepassxc/KeePassXcConfig.java
+++ b/src/main/java/abex/os/keepassxc/KeePassXcConfig.java
@@ -8,13 +8,13 @@ import net.runelite.client.config.ConfigItem;
 public interface KeePassXcConfig extends Config
 {
 	@ConfigItem(
-			keyName = "defaultFirstEntry",
-			name = "Default to First Entry",
-			description = "Use the first login entry found in the database",
+			keyName = "defaultTitle",
+			name = "Default to Entry Title",
+			description = "The Title of the login Entry to auto-populate",
 			position = 1
 	)
-	default boolean defaultFirstEntry()
+	default String defaultTitle()
 	{
-		return false;
+		return "";
 	}
 }

--- a/src/main/java/abex/os/keepassxc/KeePassXcPanel.java
+++ b/src/main/java/abex/os/keepassxc/KeePassXcPanel.java
@@ -111,17 +111,16 @@ public class KeePassXcPanel extends PluginPanel
 		setLayout(new DynamicGridLayout(0, 1, 0, 0));
 		boolean hideUsernames = client.getPreferences().getHideUsername();
 
-		if (config.defaultFirstEntry())
-		{
-			GetLogins.Entry e = logins.getEntries().get(0);
-			client.setPassword(e.getPassword());
-			client.setUsername(e.getLogin());
-			close();
-			return;
-		}
-
 		for (GetLogins.Entry e : logins.getEntries())
 		{
+			if (e.getName().equals(config.defaultTitle()))
+			{
+				client.setPassword(e.getPassword());
+				client.setUsername(e.getLogin());
+				close();
+				return;
+			}
+
 			String name = hideUsernames ? e.getName() : e.getLogin();
 			JButton b = new JButton(name);
 			b.addActionListener(_e ->

--- a/src/main/java/abex/os/keepassxc/KeePassXcPanel.java
+++ b/src/main/java/abex/os/keepassxc/KeePassXcPanel.java
@@ -33,6 +33,9 @@ public class KeePassXcPanel extends PluginPanel
 	private final NavigationButton button;
 
 	@Inject
+	private KeePassXcConfig config;
+
+	@Inject
 	public KeePassXcPanel(Client client, ClientToolbar clientToolbar)
 	{
 		this.client = client;
@@ -107,6 +110,16 @@ public class KeePassXcPanel extends PluginPanel
 		SwingUtil.fastRemoveAll(this);
 		setLayout(new DynamicGridLayout(0, 1, 0, 0));
 		boolean hideUsernames = client.getPreferences().getHideUsername();
+
+		if (config.defaultFirstEntry())
+		{
+			GetLogins.Entry e = logins.getEntries().get(0);
+			client.setPassword(e.getPassword());
+			client.setUsername(e.getLogin());
+			close();
+			return;
+		}
+
 		for (GetLogins.Entry e : logins.getEntries())
 		{
 			String name = hideUsernames ? e.getName() : e.getLogin();

--- a/src/main/java/abex/os/keepassxc/KeePassXcPanel.java
+++ b/src/main/java/abex/os/keepassxc/KeePassXcPanel.java
@@ -113,12 +113,10 @@ public class KeePassXcPanel extends PluginPanel
 
 		for (GetLogins.Entry e : logins.getEntries())
 		{
-			if (e.getName().equals(config.defaultTitle()))
+			if (e.getName().equals(config.defaultTitle()) && config.autoPopulate())
 			{
 				client.setPassword(e.getPassword());
 				client.setUsername(e.getLogin());
-				close();
-				return;
 			}
 
 			String name = hideUsernames ? e.getName() : e.getLogin();

--- a/src/main/java/abex/os/keepassxc/KeePassXcPlugin.java
+++ b/src/main/java/abex/os/keepassxc/KeePassXcPlugin.java
@@ -1,14 +1,16 @@
 package abex.os.keepassxc;
 
-import net.runelite.client.plugins.Plugin;
-import net.runelite.client.plugins.PluginDescriptor;
 import javax.inject.Inject;
 import javax.swing.SwingUtilities;
+import com.google.inject.Provides;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -22,6 +24,9 @@ public class KeePassXcPlugin extends Plugin
 
 	@Inject
 	private ClientThread clientThread;
+
+	@Inject
+	private KeePassXcConfig config;
 
 	private KeePassXcPanel panel;
 
@@ -39,6 +44,12 @@ public class KeePassXcPlugin extends Plugin
 	{
 		panel.close();
 		isTicking = false;
+	}
+
+	@Provides
+	KeePassXcConfig getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(KeePassXcConfig.class);
 	}
 
 	private int lastLoginState = -1;


### PR DESCRIPTION
I added a configuration menu and an option to have the first login entry auto-populate. When enabled, after clicking 'Existing User' the 'Login' and 'Password' fields will populate with the first element of `GetLogins.Response logins`.


![image](https://user-images.githubusercontent.com/85463994/130372117-e67442f2-6d93-47d0-8e7d-e51e52c58539.png)
