### PR TITLE
Add option to collapse/close sidebar after fill

### DIFF
--- a/src/main/java/abex/os/keepassxc/KeePassXcConfig.java
+++ b/src/main/java/abex/os/keepassxc/KeePassXcConfig.java
@@ -16,4 +16,11 @@ public interface KeePassXcConfig extends Config
 	{
 		return "";
 	}
+
+	@ConfigItem(
+			keyName = "restoreState",
+			name = "Collapse/close sidebar after fill",
+			description = "Collapse/close the sidebar if it was collapsed/closed before the autofill menu was opened."
+	)
+	default boolean restoreSidebarState() { return true; }
 }


### PR DESCRIPTION
This addresses #4. The option is enabled by default. Checks the sidebar width before creating the nav button, then uses that to decide if it should close or contract the sidebar after destroying the nav button.