### PR TITLE
Add option to prevent auto-opening sidebar

### DIFF
--- a/src/main/java/abex/os/keepassxc/KeePassXcConfig.java
+++ b/src/main/java/abex/os/keepassxc/KeePassXcConfig.java
@@ -16,4 +16,11 @@ public interface KeePassXcConfig extends Config
 	{
 		return "";
 	}
+
+	@ConfigItem(
+			keyName = "autoOpenPanel",
+			name = "Auto open panel",
+			description = "Whether or not to open the sidebar panel on the login screen"
+	)
+	default boolean autoOpenPanel() {return true;}
 }

--- a/src/main/java/abex/os/keepassxc/KeePassXcPanel.java
+++ b/src/main/java/abex/os/keepassxc/KeePassXcPanel.java
@@ -158,7 +158,7 @@ public class KeePassXcPanel extends PluginPanel
 	{
 		revalidate();
 		clientToolbar.addNavigation(button);
-		if (!button.isSelected())
+		if (!button.isSelected() && config.autoOpenPanel())
 		{
 			SwingUtilities.invokeLater(() -> button.getOnSelect().run());
 		}


### PR DESCRIPTION
Another attempt to address #4, legal this time. When using auto-fill, there is no need to open the sidebar panel (especially since we can't close it). This PR adds a toggle which controls whether or not the panel opens.

Not really useful if you're not auto-filling, but I don't see any harm in leaving the option in.