### PR TITLE
add totp support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.33.1'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	implementation 'org.zeromq:jnacl:0.1.0'
@@ -27,9 +27,9 @@ dependencies {
 
 	testImplementation 'junit:junit:4.12'
 	testImplementation group: 'net.runelite', name: 'client', version: runeLiteVersion
+	testImplementation group: 'net.runelite', name: 'jshell', version: runeLiteVersion
 }
 
-group = 'abex.autofill.keepassxc'
 version = '1.1.3'
 sourceCompatibility = '1.8'
 

--- a/src/main/java/abex/os/keepassxc/KeePassXcConfig.java
+++ b/src/main/java/abex/os/keepassxc/KeePassXcConfig.java
@@ -43,4 +43,14 @@ public interface KeePassXcConfig extends Config
 		AUTO,
 		NEVER;
 	}
+
+	@ConfigItem(
+		keyName = "performTotp",
+		name = "Perform TOTP",
+		description = "If an entry has TOTP configured within the database, auto-fill the TOTP field when prompted."
+	)
+	default boolean performTotp()
+	{
+		return true;
+	}
 }

--- a/src/main/java/abex/os/keepassxc/KeePassXcPanel.java
+++ b/src/main/java/abex/os/keepassxc/KeePassXcPanel.java
@@ -120,17 +120,12 @@ public class KeePassXcPanel extends PluginPanel
 		{
 			if (!defaultTitle.isEmpty() && e.getName().trim().equalsIgnoreCase(defaultTitle))
 			{
-				client.setPassword(e.getPassword());
-				client.setUsername(e.getLogin());
+				fillCredentials(e);
 			}
 
 			String name = hideUsernames ? e.getName() : e.getLogin();
 			JButton b = new JButton(name);
-			b.addActionListener(_e ->
-			{
-				client.setPassword(e.getPassword());
-				client.setUsername(e.getLogin());
-			});
+			b.addActionListener(_e -> fillCredentials(e));
 			add(b);
 		}
 		open();
@@ -172,5 +167,20 @@ public class KeePassXcPanel extends PluginPanel
 		// clientui doesn't unset selected if we close the panel by removing the navbutton
 		button.setSelected(false);
 		clientToolbar.removeNavigation(button);
+	}
+
+	private void fillCredentials(GetLogins.Entry e)
+	{
+		client.setPassword(e.getPassword());
+		client.setUsername(e.getLogin());
+
+		if (e.getTotp() != null && config.performTotp())
+		{
+			client.setOtp(e.getTotp());
+		}
+		else
+		{
+			client.setOtp("");
+		}
 	}
 }

--- a/src/main/java/abex/os/keepassxc/proto/msg/GetLogins.java
+++ b/src/main/java/abex/os/keepassxc/proto/msg/GetLogins.java
@@ -33,5 +33,6 @@ public class GetLogins
 		String login;
 		String name;
 		String password;
+		String totp;
 	}
 }


### PR DESCRIPTION
The totp field is returned in a `get-logins` request, or can be queried separately with `get-totp { uuid: ... }`. If totp is not configured for an entry, it is nulled.

Surprisingly, the client does not clear the totp field between `LOGIN_SCREEN` and `LOGIN_SCREEN_AUTHENTICATOR`, so we can use the same GetLogins call to immediately fill the totp field as well. This has one potential issue where the user sits on the login screen after the credentials are filled long enough for the totp to expire, although this could also happen on the totp screen.

I have another implementation that fills the totp via a `get-totp` call when it is actually requested, if preferred, but it introduces additional complexity.