### PR TITLE
add triggerUnlock support

### DIFF
--- a/src/main/java/abex/os/keepassxc/KeePassXcConfig.java
+++ b/src/main/java/abex/os/keepassxc/KeePassXcConfig.java
@@ -53,4 +53,14 @@ public interface KeePassXcConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "triggerUnlock",
+		name = "Prompt for Database Unlock",
+		description = "If the database is locked when it is accessed, ask it to pop up with an unlock prompt."
+	)
+	default boolean triggerUnlock()
+	{
+		return true;
+	}
 }

--- a/src/main/java/abex/os/keepassxc/KeePassXcPanel.java
+++ b/src/main/java/abex/os/keepassxc/KeePassXcPanel.java
@@ -61,7 +61,7 @@ public class KeePassXcPanel extends PluginPanel
 		{
 			String message;
 			Throwable ex;
-			try (KeePassXCSocket sock = new KeePassXCSocket(gson))
+			try (KeePassXCSocket sock = new KeePassXCSocket(gson, config.triggerUnlock()))
 			{
 				sock.setDeadline(500);
 				sock.init();

--- a/src/main/java/abex/os/keepassxc/proto/KeePassXCSocket.java
+++ b/src/main/java/abex/os/keepassxc/proto/KeePassXCSocket.java
@@ -24,8 +24,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.AllArgsConstructor;
-import lombok.RequiredArgsConstructor;
-import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.RuneLite;
 
@@ -40,6 +38,7 @@ public class KeePassXCSocket implements Closeable
 	private static final int ID_SIZE = 24;
 
 	private final Gson gson;
+	private final boolean allowTriggerUnlock;
 	private final Process proc;
 	private final InterruptableInputStream stdoutInterrupt;
 	private final LittleEndianDataOutputStream stdin;
@@ -54,7 +53,7 @@ public class KeePassXCSocket implements Closeable
 
 	private final SecureRandom secureRandom = new SecureRandom();
 
-	public KeePassXCSocket(Gson clientGson) throws IOException
+	public KeePassXCSocket(Gson clientGson, boolean allowTriggerUnlock) throws IOException
 	{
 		String keepassProxyPath = ProxyPathResolver.getKeepassProxyPath();
 		if (keepassProxyPath == null)
@@ -62,6 +61,7 @@ public class KeePassXCSocket implements Closeable
 			throw KeePassException.create(0, "Could not locate keepass-proxy.");
 		}
 
+		this.allowTriggerUnlock = allowTriggerUnlock;
 		this.gson = clientGson.newBuilder()
 			.disableHtmlEscaping()
 			.registerTypeHierarchyAdapter(byte[].class, new Base64Adapter())
@@ -183,6 +183,8 @@ public class KeePassXCSocket implements Closeable
 
 	public synchronized <T> T call(String action, Object send, Class<T> type, boolean triggerUnlock) throws IOException
 	{
+		boolean unlock = triggerUnlock && this.allowTriggerUnlock;
+
 		byte[] nonce = new byte[ID_SIZE];
 		secureRandom.nextBytes(nonce);
 
@@ -190,7 +192,7 @@ public class KeePassXCSocket implements Closeable
 		byte[] cryptMsgAndGarbage = nacl.encrypt(rawMsg, nonce);
 		byte[] cryptMsg = new byte[cryptMsgAndGarbage.length - curve25519xsalsa20poly1305.crypto_secretbox_BOXZEROBYTES];
 		System.arraycopy(cryptMsgAndGarbage, curve25519xsalsa20poly1305.crypto_secretbox_BOXZEROBYTES, cryptMsg, 0, cryptMsg.length);
-		byte[] wrappedMsg = gson.toJson(new RequestWrapper(action, cryptMsg, nonce, clientID, Boolean.toString(triggerUnlock)))
+		byte[] wrappedMsg = gson.toJson(new RequestWrapper(action, cryptMsg, nonce, clientID, Boolean.toString(unlock)))
 			.getBytes(StandardCharsets.UTF_8);
 
 		stdin.writeInt(wrappedMsg.length);

--- a/src/main/java/abex/os/keepassxc/proto/KeePassXCSocket.java
+++ b/src/main/java/abex/os/keepassxc/proto/KeePassXCSocket.java
@@ -8,7 +8,6 @@ import abex.os.keepassxc.proto.path.ProxyPathResolver;
 import com.google.common.io.LittleEndianDataInputStream;
 import com.google.common.io.LittleEndianDataOutputStream;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import com.neilalexander.jnacl.NaCl;
 import com.neilalexander.jnacl.crypto.curve25519xsalsa20poly1305;
@@ -25,6 +24,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.RuneLite;
 
@@ -156,6 +157,7 @@ public class KeePassXCSocket implements Closeable
 		byte[] message;
 		byte[] nonce;
 		byte[] clientID;
+		String triggerUnlock;
 	}
 
 	private static class ResponseWrapper
@@ -176,6 +178,11 @@ public class KeePassXCSocket implements Closeable
 
 	public synchronized <T> T call(String action, Object send, Class<T> type) throws IOException
 	{
+		return call(action, send, type, false);
+	}
+
+	public synchronized <T> T call(String action, Object send, Class<T> type, boolean triggerUnlock) throws IOException
+	{
 		byte[] nonce = new byte[ID_SIZE];
 		secureRandom.nextBytes(nonce);
 
@@ -183,7 +190,7 @@ public class KeePassXCSocket implements Closeable
 		byte[] cryptMsgAndGarbage = nacl.encrypt(rawMsg, nonce);
 		byte[] cryptMsg = new byte[cryptMsgAndGarbage.length - curve25519xsalsa20poly1305.crypto_secretbox_BOXZEROBYTES];
 		System.arraycopy(cryptMsgAndGarbage, curve25519xsalsa20poly1305.crypto_secretbox_BOXZEROBYTES, cryptMsg, 0, cryptMsg.length);
-		byte[] wrappedMsg = gson.toJson(new RequestWrapper(action, cryptMsg, nonce, clientID))
+		byte[] wrappedMsg = gson.toJson(new RequestWrapper(action, cryptMsg, nonce, clientID, Boolean.toString(triggerUnlock)))
 			.getBytes(StandardCharsets.UTF_8);
 
 		stdin.writeInt(wrappedMsg.length);
@@ -225,7 +232,7 @@ public class KeePassXCSocket implements Closeable
 
 	synchronized void ensureAssociate() throws IOException
 	{
-		GetDatabaseHash.Response hashRes = call(GetDatabaseHash.ACTION, new GetDatabaseHash.Request(), GetDatabaseHash.Response.class);
+		GetDatabaseHash.Response hashRes = call(GetDatabaseHash.ACTION, new GetDatabaseHash.Request(), GetDatabaseHash.Response.class, true);
 		String hash = hashRes.getHash();
 		Key k = keyring.get(hash);
 		if (k != null)

--- a/src/test/java/abex/os/keepassxc/ManualTest.java
+++ b/src/test/java/abex/os/keepassxc/ManualTest.java
@@ -8,7 +8,7 @@ public class ManualTest
 {
 	public static void main(String... args) throws Exception
 	{
-		try (KeePassXCSocket s = new KeePassXCSocket(new Gson()))
+		try (KeePassXCSocket s = new KeePassXCSocket(new Gson(), false))
 		{
 			s.setDeadline(500);
 			long start = System.currentTimeMillis();


### PR DESCRIPTION
Adds the triggerUnlock field to allow the plugin to automatically prompt for db unlock if we attempt to associate while locked.

Based on the [browser implementation](https://github.com/keepassxreboot/keepassxc-browser/blob/develop/keepassxc-browser/background/client.js#L217) which is invoked (in a roundabout way) by the ["Reopen Database" button](https://github.com/keepassxreboot/keepassxc-browser/blob/b9547e7cee1e07c657f41b7035b5026460912a1d/keepassxc-browser/popups/popup_login.js#L74-L79).

Oddly it uses the string representation of the boolean and not a boolean type. Using the boolean type does NOT work.

Could maybe be gated behind a config option. Let me know if you want that.